### PR TITLE
feat(frontend): 簡単なOAuthのデモ追加

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,2 @@
+VITE_42_CLIENT_ID=<your-client-id>
+VITE_42_REDIRECT_URI=http://localhost:5173/auth/callback

--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,5 @@ setup:
 	volta install pnpm@${shell jq -r '.volta.pnpm' ./package.json}
 
 	pnpm install && pnpm build
+
+	ln -s ${PWD}/.env ${PWD}/apps/frontend/.env

--- a/apps/backend/src/auth/authTest.ts
+++ b/apps/backend/src/auth/authTest.ts
@@ -13,4 +13,4 @@ export async function authTestRoute(fastify: FastifyInstance) {
     // Simulate a successful login
     return { token: "fake-jwt-token" };
   });
-};
+}

--- a/apps/backend/src/auth/authTest.ts
+++ b/apps/backend/src/auth/authTest.ts
@@ -1,0 +1,16 @@
+import type { FastifyInstance, FastifyRequest } from "fastify";
+
+export async function authTestRoute(fastify: FastifyInstance) {
+  fastify.post("/api/auth/login", async (request: FastifyRequest, reply) => {
+    const { code } = request.body as { code?: string };
+
+    if (!code) {
+      return reply.status(400).send({ error: "Missing code" });
+    }
+
+    console.log("Received code:", code);
+
+    // Simulate a successful login
+    return { token: "fake-jwt-token" };
+  });
+};

--- a/apps/backend/src/auth/index.ts
+++ b/apps/backend/src/auth/index.ts
@@ -1,0 +1,1 @@
+export * from "./authTest.js";

--- a/apps/backend/src/buildApp.ts
+++ b/apps/backend/src/buildApp.ts
@@ -1,5 +1,6 @@
 import Fastify, { type FastifyInstance } from "fastify";
 import { healthRoute } from "./health/index.js";
+import { authTestRoute } from "./auth/authTest.js";
 
 export async function buildApp(): Promise<FastifyInstance> {
   const fastify: FastifyInstance = Fastify({
@@ -7,6 +8,7 @@ export async function buildApp(): Promise<FastifyInstance> {
   });
 
   fastify.register(healthRoute);
+  fastify.register(authTestRoute);
 
   return fastify;
 }

--- a/apps/backend/src/buildApp.ts
+++ b/apps/backend/src/buildApp.ts
@@ -1,6 +1,6 @@
 import Fastify, { type FastifyInstance } from "fastify";
-import { healthRoute } from "./health/index.js";
 import { authTestRoute } from "./auth/authTest.js";
+import { healthRoute } from "./health/index.js";
 
 export async function buildApp(): Promise<FastifyInstance> {
   const fastify: FastifyInstance = Fastify({

--- a/apps/frontend/src/features/auth/handleAuthCallback.ts
+++ b/apps/frontend/src/features/auth/handleAuthCallback.ts
@@ -1,0 +1,36 @@
+export async function handleAuthCallback(): Promise<void> {
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get("code");
+    const state = params.get("state");
+
+    if (!code || !state) {
+        window.location.href = "/";
+    }
+
+    // CSRF対策のため、保存しておいたstateと照合
+    const savedState = sessionStorage.getItem("oauth_state");
+    sessionStorage.removeItem("oauth_state");
+    if (!savedState || !state || savedState !== state) {
+        window.location.href = "/";
+    }
+
+    try {
+        const response = await fetch("/api/auth/login", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ code }),
+        });
+
+        const { token } = await response.json();
+        if (token) {
+            localStorage.setItem("auth_token", token);
+            window.location.href = "/dashboard";
+        } else {
+            window.location.href = "/";
+        }
+    } catch (_error) {
+        window.location.href = "/";
+    }
+};

--- a/apps/frontend/src/features/auth/index.ts
+++ b/apps/frontend/src/features/auth/index.ts
@@ -1,0 +1,2 @@
+export * from "./handleAuthCallback";
+export * from "./redirect42";

--- a/apps/frontend/src/features/auth/redirect42.ts
+++ b/apps/frontend/src/features/auth/redirect42.ts
@@ -1,17 +1,17 @@
 export async function redirectTo42Auth(): Promise<void> {
-    const clientId = import.meta.env.VITE_42_CLIENT_ID;
-    const redirectUri = import.meta.env.VITE_42_REDIRECT_URI;
-    const state = crypto.randomUUID(); // CSRF対策のためのランダムなstateを生成
-    
-    sessionStorage.setItem("oauth_state", state);
+  const clientId = import.meta.env.VITE_42_CLIENT_ID;
+  const redirectUri = import.meta.env.VITE_42_REDIRECT_URI;
+  const state = crypto.randomUUID(); // CSRF対策のためのランダムなstateを生成
 
-    const params = new URLSearchParams({
-        client_id: clientId,
-        redirect_uri: redirectUri,
-        scope: "public",
-        response_type: "code",
-        state: state,
-    });
+  sessionStorage.setItem("oauth_state", state);
 
-    window.location.href = `https://api.intra.42.fr/oauth/authorize?${params.toString()}`;
-};
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    scope: "public",
+    response_type: "code",
+    state: state,
+  });
+
+  window.location.href = `https://api.intra.42.fr/oauth/authorize?${params.toString()}`;
+}

--- a/apps/frontend/src/features/auth/redirect42.ts
+++ b/apps/frontend/src/features/auth/redirect42.ts
@@ -1,0 +1,17 @@
+export async function redirectTo42Auth(): Promise<void> {
+    const clientId = import.meta.env.VITE_42_CLIENT_ID;
+    const redirectUri = import.meta.env.VITE_42_REDIRECT_URI;
+    const state = crypto.randomUUID(); // CSRF対策のためのランダムなstateを生成
+    
+    sessionStorage.setItem("oauth_state", state);
+
+    const params = new URLSearchParams({
+        client_id: clientId,
+        redirect_uri: redirectUri,
+        scope: "public",
+        response_type: "code",
+        state: state,
+    });
+
+    window.location.href = `https://api.intra.42.fr/oauth/authorize?${params.toString()}`;
+};

--- a/apps/frontend/src/features/index.ts
+++ b/apps/frontend/src/features/index.ts
@@ -1,0 +1,1 @@
+export * from "./auth";

--- a/apps/frontend/src/main.ts
+++ b/apps/frontend/src/main.ts
@@ -1,4 +1,5 @@
 import { fetchHealth } from "./example";
+import { redirectTo42Auth, handleAuthCallback } from "./features";
 import { componentFactory } from "./factory/componentFactory";
 import { eh } from "./factory/elementFactory";
 import "../style.css";
@@ -39,3 +40,23 @@ toggleBtn.addEventListener("click", () => {
     toggleBtn.textContent = "Hide";
   }
 });
+
+// --- 簡易的なルーター ---
+const path = window.location.pathname;
+if (path === "/auth/callback") {
+  root.innerHTML = "<p>Authenticating, please wait...</p>";
+  handleAuthCallback();
+} else if (path === "/dashboard") {
+  const token = localStorage.getItem("auth_token")
+  root.innerHTML = `<h1>Your token is: ${token}</h1>`;
+} else {
+  const signInButton = eh(
+    "button",
+    { className: "px-4 py-2 bg-blue-600 text-white rounded" },
+    "Sign in with 42",
+  );
+  signInButton.addEventListener("click", redirectTo42Auth);
+  
+  root.appendChild(signInButton);
+}
+

--- a/apps/frontend/src/main.ts
+++ b/apps/frontend/src/main.ts
@@ -1,7 +1,7 @@
 import { fetchHealth } from "./example";
-import { redirectTo42Auth, handleAuthCallback } from "./features";
 import { componentFactory } from "./factory/componentFactory";
 import { eh } from "./factory/elementFactory";
+import { handleAuthCallback, redirectTo42Auth } from "./features";
 import "../style.css";
 
 const status = await fetchHealth();
@@ -47,7 +47,7 @@ if (path === "/auth/callback") {
   root.innerHTML = "<p>Authenticating, please wait...</p>";
   handleAuthCallback();
 } else if (path === "/dashboard") {
-  const token = localStorage.getItem("auth_token")
+  const token = localStorage.getItem("auth_token");
   root.innerHTML = `<h1>Your token is: ${token}</h1>`;
 } else {
   const signInButton = eh(
@@ -56,7 +56,6 @@ if (path === "/auth/callback") {
     "Sign in with 42",
   );
   signInButton.addEventListener("click", redirectTo42Auth);
-  
+
   root.appendChild(signInButton);
 }
-


### PR DESCRIPTION
- login処理一歩手前までのデモを追加した
- VITE_42_CLIENT_ID=<your-client-id>は自分のintraでアプリ作る感じ(自分の渡してもまあいい)
- ln -s ${PWD}/.env ${PWD}/apps/frontend/.env で.envのシンボリックリンクを生やす