### PR TITLE
fix(backend): JWTを用いたリクエストの追加

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -20,6 +20,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@fastify/cookie": "^11.0.2",
     "fastify": "5.6.1",
     "fastify-plugin": "5.0.1",
     "jsonwebtoken": "9.0.2",

--- a/apps/backend/src/auth/authRoute.ts
+++ b/apps/backend/src/auth/authRoute.ts
@@ -50,6 +50,14 @@ export async function authRoute(fastify: FastifyInstance) {
     const jwtPayload = { id: user.id, name: user.name };
     const token = jwt.sign(jwtPayload, jwtSecret, { expiresIn: "1h" });
 
-    return { token };
+    reply.setCookie("token", token, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "strict",
+      path: "/",
+      expires: new Date(Date.now() + 60 * 60 * 1000), // 1 hour
+    });
+
+    return reply.status(200).send();
   });
 }

--- a/apps/backend/src/buildApp.ts
+++ b/apps/backend/src/buildApp.ts
@@ -1,3 +1,4 @@
+import cookie from "@fastify/cookie";
 import Fastify, { type FastifyInstance } from "fastify";
 import { authRoute } from "./auth/authRoute.js";
 
@@ -7,6 +8,7 @@ export async function buildApp(): Promise<FastifyInstance> {
   });
 
   fastify.register(authRoute);
+  fastify.register(cookie);
 
   return fastify;
 }

--- a/apps/backend/src/buildApp.ts
+++ b/apps/backend/src/buildApp.ts
@@ -1,6 +1,7 @@
 import cookie from "@fastify/cookie";
 import Fastify, { type FastifyInstance } from "fastify";
 import { authRoute } from "./auth/authRoute.js";
+import { getMe } from "./user/me.js";
 
 export async function buildApp(): Promise<FastifyInstance> {
   const fastify: FastifyInstance = Fastify({
@@ -8,6 +9,7 @@ export async function buildApp(): Promise<FastifyInstance> {
   });
 
   fastify.register(authRoute);
+  fastify.register(getMe);
   fastify.register(cookie);
 
   return fastify;

--- a/apps/backend/src/user/me.ts
+++ b/apps/backend/src/user/me.ts
@@ -1,6 +1,6 @@
 import "dotenv/config";
 import type { FastifyInstance, FastifyRequest } from "fastify";
-import jwt from 'jsonwebtoken';
+import jwt from "jsonwebtoken";
 
 export async function getMe(fastify: FastifyInstance) {
   fastify.get("/api/user/me", async (request: FastifyRequest, reply) => {
@@ -15,9 +15,10 @@ export async function getMe(fastify: FastifyInstance) {
     }
 
     try {
-      const decoded = jwt.verify(
-        token, jwtSecret
-      ) as { id: number; name: string };
+      const decoded = jwt.verify(token, jwtSecret) as {
+        id: number;
+        name: string;
+      };
       return { id: decoded.id, name: decoded.name };
     } catch {
       return reply.status(401).send({ error: "Invalid token" });

--- a/apps/backend/src/user/me.ts
+++ b/apps/backend/src/user/me.ts
@@ -1,0 +1,26 @@
+import "dotenv/config";
+import type { FastifyInstance, FastifyRequest } from "fastify";
+import jwt from 'jsonwebtoken';
+
+export async function getMe(fastify: FastifyInstance) {
+  fastify.get("/api/user/me", async (request: FastifyRequest, reply) => {
+    const token = request.cookies.token;
+    if (!token) {
+      return reply.status(401).send({ error: "Unauthorized" });
+    }
+
+    const jwtSecret = process.env.JWT_SECRET;
+    if (!jwtSecret) {
+      return reply.status(500).send();
+    }
+
+    try {
+      const decoded = jwt.verify(
+        token, jwtSecret
+      ) as { id: number; name: string };
+      return { id: decoded.id, name: decoded.name };
+    } catch {
+      return reply.status(401).send({ error: "Invalid token" });
+    }
+  });
+}

--- a/apps/frontend/src/features/auth/handleAuthCallback.ts
+++ b/apps/frontend/src/features/auth/handleAuthCallback.ts
@@ -23,12 +23,11 @@ export async function handleAuthCallback(): Promise<void> {
       body: JSON.stringify({ code }),
     });
 
-    const { token } = await response.json();
-    if (token) {
-      localStorage.setItem("auth_token", token);
-      window.location.href = "/dashboard";
-    } else {
+    if (!response.ok) {
       window.location.href = "/";
+      return;
+    } else {
+      window.location.href = "/dashboard";
     }
   } catch (_error) {
     window.location.href = "/";

--- a/apps/frontend/src/main.ts
+++ b/apps/frontend/src/main.ts
@@ -55,7 +55,14 @@ if (path === "/auth/callback") {
   root.innerHTML = "<p>Authenticating, please wait...</p>";
   handleAuthCallback();
 } else if (path === "/dashboard") {
-  root.innerHTML = `<h1>dashboard</h1>`;
+  const res = await fetch("/api/user/me", {
+    method: "GET",
+    credentials: "include", // cookie内のJWTを送信するために必要
+  });
+  if (res.status === 200) {
+    const data = await res.json();
+    root.innerHTML = `<h1>dashboard</h1><p>Welcome, ${data.name}!</p>`;
+  }
 } else {
   const signInButton = eh(
     "button",

--- a/apps/frontend/src/main.ts
+++ b/apps/frontend/src/main.ts
@@ -55,8 +55,7 @@ if (path === "/auth/callback") {
   root.innerHTML = "<p>Authenticating, please wait...</p>";
   handleAuthCallback();
 } else if (path === "/dashboard") {
-  const token = localStorage.getItem("auth_token");
-  root.innerHTML = `<h1>Your token is: ${token}</h1>`;
+  root.innerHTML = `<h1>dashboard</h1>`;
 } else {
   const signInButton = eh(
     "button",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -34,13 +34,6 @@ paths:
                 - code
       responses:
         '200':
-          description: 成功時にJWTトークンを返します。
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  token:
-                    type: string
-                    description: 発行されたJWTトークン
+          description: 成功時、JWTトークンをhttpOnly cookieに設定します。
+
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
 
   apps/backend:
     dependencies:
+      '@fastify/cookie':
+        specifier: ^11.0.2
+        version: 11.0.2
       fastify:
         specifier: 5.6.1
         version: 5.6.1
@@ -287,6 +290,9 @@ packages:
 
   '@fastify/ajv-compiler@4.0.2':
     resolution: {integrity: sha512-Rkiu/8wIjpsf46Rr+Fitd3HRP+VsxUFDDeag0hs9L0ksfnwx2g7SPQQTFL0E8Qv+rfXzQOxBJnjUB9ITUDjfWQ==}
+
+  '@fastify/cookie@11.0.2':
+    resolution: {integrity: sha512-GWdwdGlgJxyvNv+QcKiGNevSspMQXncjMZ1J8IvuDQk0jvkzgWWZFNC2En3s+nHndZBGV8IbLwOI/sxCZw/mzA==}
 
   '@fastify/error@4.2.0':
     resolution: {integrity: sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==}
@@ -1854,6 +1860,11 @@ snapshots:
       ajv: 8.17.1
       ajv-formats: 3.0.1(ajv@8.17.1)
       fast-uri: 3.1.0
+
+  '@fastify/cookie@11.0.2':
+    dependencies:
+      cookie: 1.0.2
+      fastify-plugin: 5.0.1
 
   '@fastify/error@4.2.0': {}
 


### PR DESCRIPTION
- JWTをlocalストレージに保存するのではなく、httpOnly cookieに保存するように変更
  - XSSの緩和策
  - 緩和策であって本質的対策ではないので、課題要件を満たすために入力サニタイズや出力エスケープは別に必要
- JWTを用いたリクエストの追加
  - 通常のfetchに`credentials: "include"`を付けると、自動的にJWTを送信してくれる
```
const res = await fetch("/api/user/me", {
    method: "GET",
    credentials: "include", // cookie内のJWTを送信するために必要
  });
```