### PR TITLE
56 frontendのルーティングのリファクタリング

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,0 @@
-VITE_42_CLIENT_ID=<your-client-id>
-VITE_42_REDIRECT_URI=http://localhost:5173/auth/callback
-CLIENT_SECRET=<your-client-secret>
-JWT_SECRET=<your-jwt-secret-key>

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -33,5 +33,3 @@ COPY --from=builder /builder/apps/frontend/nginx.conf /etc/nginx/conf.d/default.
 EXPOSE 5173
 
 CMD ["nginx", "-g", "daemon off;"]
-
-

--- a/apps/frontend/src/factory/layoutFactory.ts
+++ b/apps/frontend/src/factory/layoutFactory.ts
@@ -9,7 +9,7 @@ export type LayoutProps = {
 };
 
 export type Layout = ElComponent & {
-  setPage: (page: ElComponent) => void;
+  setPage: (page: ElComponent | Promise<ElComponent>) => void;
 };
 
 //propsとして渡されるmainはmainFactoryで作られたもの。layoutの中ではsetPageでページを変更する。
@@ -44,10 +44,16 @@ export const layoutFactory = (props: LayoutProps): Layout => {
       mounted = false;
     },
 
-    setPage(next: ElComponent) {
-      if (currentPage) currentPage.unmount();
-      next.mount(props.main.el, props.main.slotAnchor);
-      currentPage = next;
+    setPage(next: ElComponent | Promise<ElComponent>) {
+      if (currentPage) {
+        currentPage.unmount();
+        currentPage = null;
+      }
+      Promise.resolve(next).then((resolved) => {
+        resolved.mount(props.main.el, props.main.slotAnchor);
+        //非同期が終わった要素だけ代入
+        currentPage = resolved;
+      });
     },
   };
 };

--- a/apps/frontend/src/main.ts
+++ b/apps/frontend/src/main.ts
@@ -1,12 +1,13 @@
-import { handleAuthCallback } from "./features";
+// import { handleAuthCallback } from "./features";
 import "../style.css";
 import { Footer } from "./components/footer";
 import { Header } from "./components/header";
 import type { ElComponent } from "./factory/componentFactory";
 import { layoutFactory } from "./factory/layoutFactory";
 import { mainSlotFactory } from "./factory/mainSlotFactory";
-import type { Params, Route } from "./routing/routeList";
+// import type { Params, Route } from "./routing/routeList";
 import { routeList } from "./routing/routeList";
+import { createRouter } from "./routing/router";
 
 const root = document.querySelector<HTMLElement>("#app");
 if (!root) throw new Error("#app not found");
@@ -20,167 +21,178 @@ const main = mainSlotFactory();
 //layoutも作ってそこにheader, main, footerを突っ込む
 const layout = layoutFactory({ header, main, footer });
 
+const router = createRouter({
+  routes: routeList,
+  layout,
+  rootEl: root,
+  onNavigateError: () => {
+    console.error("navigattion error");
+  },
+});
+
+router.init();
+
 // 動的ルーティング
-function matchRoute(
-  pathname: string,
-  routes: Route[],
-): { route: Route; params: Params } {
-  // 静的パスマッチング
-  const staticMatch = routes.find((r) => r.path === pathname);
-  if (staticMatch) return { route: staticMatch, params: {} };
-
-  // 動的パスマッチング
-  for (const route of routes) {
-    if (!route.path.includes(":")) continue;
-
-    const routeParts = route.path.split("/").filter(Boolean);
-    const pathParts = pathname.split("/").filter(Boolean);
-
-    if (routeParts.length !== pathParts.length) continue;
-
-    const params: Params = {};
-    let isMatch = true;
-
-    for (let i = 0; i < routeParts.length; i++) {
-      if (routeParts[i].startsWith(":")) {
-        const paramName = routeParts[i].slice(1);
-        params[paramName] = pathParts[i];
-      } else if (routeParts[i] !== pathParts[i]) {
-        isMatch = false;
-        break;
-      }
-    }
-
-    if (isMatch) return { route, params };
-  }
-
-  return { route: routes[routes.length - 1], params: {} };
-}
-
-// ルーティング設定（カスタムナビゲーション用）
-
-// グローバルなページ管理システム
-let currentPageType: "root" | "layout" = "root";
-let currentRootPage: ElComponent | null = null;
-
-// カスタムナビゲーション処理
-const handleNavigation = async (pathname: string, pushState = true) => {
-  if (pathname === "/") {
-    // ルートページへの遷移
-    if (currentPageType === "layout") {
-      layout.unmount();
-    }
-
-    root.innerHTML = "";
-    const { Home } = await import("./pages/main");
-    if (currentRootPage) {
-      currentRootPage.unmount();
-    }
-    currentRootPage = Home;
-    Home.mount(root);
-    currentPageType = "root";
-
-    if (pushState) {
-      history.pushState(null, "", pathname);
-    }
-  } else {
-    // レイアウト付きページへの遷移
-    if (currentPageType === "root") {
-      root.innerHTML = "";
-      if (currentRootPage) {
-        currentRootPage.unmount();
-        currentRootPage = null;
-      }
-      layout.mount(root);
-    }
-    currentPageType = "layout";
-
-    // 通常のルーティング処理を手動実行
-    const u = new URL(pathname, location.origin);
-    const normPath = pathname === "/" ? "/" : pathname.replace(/\/$/, "");
-    const query = u.searchParams;
-
-    // ルートを見つけてページを設定
-    const { route, params } = matchRoute(normPath, routeList);
-    const ctx = { params, query };
-    const page = route.viewFactory(ctx);
-    layout.setPage(page);
-
-    if (pushState) {
-      history.pushState(null, "", pathname);
-    }
-  }
-};
-
-// グローバルクリックハンドラー
-document.addEventListener("click", async (ev) => {
-  const a = (ev.target as HTMLElement)?.closest(
-    "a",
-  ) as HTMLAnchorElement | null;
-  if (!a) return;
-  if (a.target && a.target !== "_self") return;
-  if (a.hasAttribute("download")) return;
-  if (ev.metaKey || ev.altKey || ev.shiftKey || ev.ctrlKey) return;
-
-  const href = a.getAttribute("href");
-  if (!href || href.startsWith("http")) return;
-
-  ev.preventDefault();
-  await handleNavigation(href);
-});
-
-// ブラウザバック/フォワード処理
-window.addEventListener("popstate", async () => {
-  await handleNavigation(window.location.pathname, false);
-});
-
-// 初期化処理
-const path = window.location.pathname;
-
-if (path === "/auth/callback") {
-  root.innerHTML = "<p>Authenticating, please wait...</p>";
-
-  // ポップアップから開かれた場合の処理
-  if (window.opener) {
-    try {
-      await handleAuthCallback();
-      // 親ウィンドウに成功を通知
-      window.opener.postMessage(
-        { type: "AUTH_SUCCESS" },
-        window.location.origin,
-      );
-      window.close();
-    } catch (error) {
-      // 親ウィンドウにエラーを通知
-      window.opener.postMessage(
-        {
-          type: "AUTH_ERROR",
-          error: error instanceof Error ? error.message : "認証に失敗しました",
-        },
-        window.location.origin,
-      );
-      window.close();
-    }
-  } else {
-    // 通常のタブで開かれた場合の従来の処理
-    handleAuthCallback();
-  }
-} else if (path === "/dashboard") {
-  const res = await fetch("/api/user/me", {
-    method: "GET",
-    credentials: "include", // cookie内のJWTを送信するために必要
-  });
-  if (res.status === 200) {
-    const data = await res.json();
-    root.innerHTML = `
-      <h1>dashboard</h1>
-      <p>Welcome, ${data.name}!</p>
-      <a href="/tournaments" class="inline-block mt-4 bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
-        トーナメント一覧
-      </a>
-    `;
-  }
-} else {
-  // 通常のページルーティング（ルートページ含む）
-  await handleNavigation(path, false);
-}
+// function matchRoute(
+//   pathname: string,
+//   routes: Route[],
+// ): { route: Route; params: Params } {
+//   // 静的パスマッチング
+//   const staticMatch = routes.find((r) => r.path === pathname);
+//   if (staticMatch) return { route: staticMatch, params: {} };
+//
+//   // 動的パスマッチング
+//   for (const route of routes) {
+//     if (!route.path.includes(":")) continue;
+//
+//     const routeParts = route.path.split("/").filter(Boolean);
+//     const pathParts = pathname.split("/").filter(Boolean);
+//
+//     if (routeParts.length !== pathParts.length) continue;
+//
+//     const params: Params = {};
+//     let isMatch = true;
+//
+//     for (let i = 0; i < routeParts.length; i++) {
+//       if (routeParts[i].startsWith(":")) {
+//         const paramName = routeParts[i].slice(1);
+//         params[paramName] = pathParts[i];
+//       } else if (routeParts[i] !== pathParts[i]) {
+//         isMatch = false;
+//         break;
+//       }
+//     }
+//
+//     if (isMatch) return { route, params };
+//   }
+//
+//   return { route: routes[routes.length - 1], params: {} };
+// }
+//
+// // ルーティング設定（カスタムナビゲーション用）
+//
+// // グローバルなページ管理システム
+// let currentPageType: "root" | "layout" = "root";
+// let currentRootPage: ElComponent | null = null;
+//
+// // カスタムナビゲーション処理
+// const handleNavigation = async (pathname: string, pushState = true) => {
+//   if (pathname === "/") {
+//     // ルートページへの遷移
+//     if (currentPageType === "layout") {
+//       layout.unmount();
+//     }
+//
+//     root.innerHTML = "";
+//     const { Home } = await import("./pages/main");
+//     if (currentRootPage) {
+//       currentRootPage.unmount();
+//     }
+//     currentRootPage = Home;
+//     Home.mount(root);
+//     currentPageType = "root";
+//
+//     if (pushState) {
+//       history.pushState(null, "", pathname);
+//     }
+//   } else {
+//     // レイアウト付きページへの遷移
+//     if (currentPageType === "root") {
+//       root.innerHTML = "";
+//       if (currentRootPage) {
+//         currentRootPage.unmount();
+//         currentRootPage = null;
+//       }
+//       layout.mount(root);
+//     }
+//     currentPageType = "layout";
+//
+//     // 通常のルーティング処理を手動実行
+//     const u = new URL(pathname, location.origin);
+//     const normPath = pathname === "/" ? "/" : pathname.replace(/\/$/, "");
+//     const query = u.searchParams;
+//
+//     // ルートを見つけてページを設定
+//     const { route, params } = matchRoute(normPath, routeList);
+//     const ctx = { params, query };
+//     const page = route.viewFactory(ctx);
+//     layout.setPage(page);
+//
+//     if (pushState) {
+//       history.pushState(null, "", pathname);
+//     }
+//   }
+// };
+//
+// // グローバルクリックハンドラー
+// document.addEventListener("click", async (ev) => {
+//   const a = (ev.target as HTMLElement)?.closest(
+//     "a",
+//   ) as HTMLAnchorElement | null;
+//   if (!a) return;
+//   if (a.target && a.target !== "_self") return;
+//   if (a.hasAttribute("download")) return;
+//   if (ev.metaKey || ev.altKey || ev.shiftKey || ev.ctrlKey) return;
+//
+//   const href = a.getAttribute("href");
+//   if (!href || href.startsWith("http")) return;
+//
+//   ev.preventDefault();
+//   await handleNavigation(href);
+// });
+//
+// // ブラウザバック/フォワード処理
+// window.addEventListener("popstate", async () => {
+//   await handleNavigation(window.location.pathname, false);
+// });
+//
+// // 初期化処理
+// const path = window.location.pathname;
+//
+// if (path === "/auth/callback") {
+//   root.innerHTML = "<p>Authenticating, please wait...</p>";
+//
+//   // ポップアップから開かれた場合の処理
+//   if (window.opener) {
+//     try {
+//       await handleAuthCallback();
+//       // 親ウィンドウに成功を通知
+//       window.opener.postMessage(
+//         { type: "AUTH_SUCCESS" },
+//         window.location.origin,
+//       );
+//       window.close();
+//     } catch (error) {
+//       // 親ウィンドウにエラーを通知
+//       window.opener.postMessage(
+//         {
+//           type: "AUTH_ERROR",
+//           error: error instanceof Error ? error.message : "認証に失敗しました",
+//         },
+//         window.location.origin,
+//       );
+//       window.close();
+//     }
+//   } else {
+//     // 通常のタブで開かれた場合の従来の処理
+//     handleAuthCallback();
+//   }
+// } else if (path === "/dashboard") {
+//   const res = await fetch("/api/user/me", {
+//     method: "GET",
+//     credentials: "include", // cookie内のJWTを送信するために必要
+//   });
+//   if (res.status === 200) {
+//     const data = await res.json();
+//     root.innerHTML = `
+//       <h1>dashboard</h1>
+//       <p>Welcome, ${data.name}!</p>
+//       <a href="/tournaments" class="inline-block mt-4 bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
+//         トーナメント一覧
+//       </a>
+//     `;
+//   }
+// } else {
+//   // 通常のページルーティング（ルートページ含む）
+//   await handleNavigation(path, false);
+// }

--- a/apps/frontend/src/routing/routeList.ts
+++ b/apps/frontend/src/routing/routeList.ts
@@ -1,12 +1,12 @@
 import type { ElComponent } from "../factory/componentFactory";
+import { componentFactory } from "../factory/componentFactory";
+import { handleAuthCallback } from "../features";
 import { NotFound } from "../pages/404";
 import { About } from "../pages/about";
 import { Home } from "../pages/main";
 import { TournamentDetail } from "../pages/tournamentDetail";
 import { Tournaments } from "../pages/tournaments";
 import { User } from "../pages/user";
-import { handleAuthCallback } from "../features";
-import { componentFactory } from "../factory/componentFactory";
 
 // { id: 15 } みたいなデータ。ユーザーidとかを扱うとき
 export type Params = Record<string, string>;
@@ -39,7 +39,7 @@ export type Route = {
   viewFactory?: ViewFactory;
   action?: (
     ctx: RouteCtx,
-  ) => void | Promise<void | RedirectResult> | RedirectResult;
+  ) => undefined | Promise<undefined | RedirectResult> | RedirectResult;
 };
 
 //これはテストようなので実際はpageコンポーネントで別ファイルとして定義した方がいい

--- a/apps/frontend/src/routing/routeList.ts
+++ b/apps/frontend/src/routing/routeList.ts
@@ -5,6 +5,8 @@ import { Home } from "../pages/main";
 import { TournamentDetail } from "../pages/tournamentDetail";
 import { Tournaments } from "../pages/tournaments";
 import { User } from "../pages/user";
+import { handleAuthCallback } from "../features";
+import { componentFactory } from "../factory/componentFactory";
 
 // { id: 15 } みたいなデータ。ユーザーidとかを扱うとき
 export type Params = Record<string, string>;
@@ -16,44 +18,119 @@ export type RouteCtx = {
 };
 
 // ctxはこの後個人ページなど人によって違うデータをdatabaseから引っ張ってきて表示する場合などにctxを使ってcomponentを作る
-export type ViewFactory = (ctx: RouteCtx) => ElComponent;
+export type ViewFactory = (ctx: RouteCtx) => ElComponent | Promise<ElComponent>;
+
+//Redirect用のオブジェクト。これを見てリダイレクト先を決定する
+export type RedirectResult = { redirect: string; replace?: boolean };
+
+//routeに入れるメタ情報
+export type RouteMeta = {
+  title?: string;
+  layout?: "none" | "app";
+  protected?: boolean;
+  loading?: ElComponent;
+};
 
 //pathとそれに対応するpage factoryを持つオブジェクトのtype
+//navigateしてviewFactoryを呼ぶ間にonEnterが発火
 export type Route = {
-  name: string;
+  meta: RouteMeta;
   path: string;
-  viewFactory: ViewFactory;
+  viewFactory?: ViewFactory;
+  action?: (
+    ctx: RouteCtx,
+  ) => void | Promise<void | RedirectResult> | RedirectResult;
+};
+
+//これはテストようなので実際はpageコンポーネントで別ファイルとして定義した方がいい
+const Dashboard = (name: string): ElComponent => {
+  const el = document.createElement("div");
+  el.innerHTML = `
+    <h1>dashboard</h1>
+    <p>Welcome, ${name}!</p>
+    <a href="/tournaments" class="inline-block mt-4 bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
+      トーナメント一覧
+    </a>
+  `;
+  return componentFactory(el);
 };
 
 //pageを追加するときはここにどんどん追加していく。not foundは必ず1番下に記述すること
 export const routeList: Route[] = [
   {
-    name: "Home",
+    meta: { title: "Home", layout: "none", protected: false },
     path: "/",
     viewFactory: () => Home,
   },
   {
-    name: "About",
+    meta: { title: "about" },
     path: "/about",
     viewFactory: () => About,
   },
   {
-    name: "Tournaments",
+    meta: { title: "tournament" },
     path: "/tournaments",
     viewFactory: () => Tournaments,
   },
   {
-    name: "TournamentDetail",
+    meta: { title: "tournamentDetail" },
     path: "/tournaments/:id",
     viewFactory: (ctx: RouteCtx) => TournamentDetail(ctx),
   },
   {
-    name: "user",
+    meta: { title: "user" },
     path: "/user/:id",
     viewFactory: (ctx: RouteCtx) => User(ctx),
   },
   {
-    name: "not found",
+    meta: { title: "dashboard", protected: true, layout: "app" },
+    path: "/dashboard",
+    viewFactory: async () => {
+      const res = await fetch("/api/user/me", {
+        method: "GET",
+        credentials: "include",
+      });
+      if (!res.ok) throw new Error("Unorthorized");
+      const data = await res.json();
+      return Dashboard(data.name ?? "User");
+    },
+  },
+  {
+    meta: { title: "Authenticating...", layout: "none" },
+    path: "/auth/callback",
+    action: async (_ctx) => {
+      try {
+        await handleAuthCallback();
+        if (window.opener) {
+          window.opener.postMessage(
+            { type: "AUTH_SUCCESS" },
+            window.location.origin,
+          );
+          window.close();
+          return;
+        } else {
+          return { redirect: "/dashboard", replace: true };
+        }
+      } catch (err: unknown) {
+        if (window.opener) {
+          window.opener.postMessage(
+            {
+              type: "AUTH_ERROR",
+              error:
+                err instanceof Error ? err.message : "Authentication Failed",
+            },
+            window.location.origin,
+          );
+          window.close();
+          return;
+        } else {
+          return { redirect: "/dashboard", replace: true };
+        }
+      }
+    },
+  },
+  {
+    meta: { title: "not found" },
     path: "*",
     viewFactory: () => NotFound,
   },

--- a/apps/frontend/src/routing/router.ts
+++ b/apps/frontend/src/routing/router.ts
@@ -79,7 +79,7 @@ export const createRouter = (props: RouteProps) => {
     if (route.viewFactory) {
       try {
         const pageOrPromise = route.viewFactory(ctx);
-        if (layoutMode == "none") {
+        if (layoutMode === "none") {
           //layoutのマウント状況を監視
           if (mountedLayout) {
             props.layout.unmount();


### PR DESCRIPTION
routingでこれまでは全てのpageをlayoutのsetPageからしかマウントできなかったものを、rootに直接マウントできるようにroutingを変更。

authやdataをフェッチしてその結果を元にpageを描画するなど非同期のページ描画に対応。
routeのtypeを
export type Route = {
  meta: RouteMeta;
  path: string;
  viewFactory?: ViewFactory;
  action?: (
    ctx: RouteCtx,
  ) => undefined | Promise<undefined | RedirectResult> | RedirectResult;
};
に変更。
actionにcb functionを実行することでroutingが発火した時に描画前に実行する関数を登録する。