### PR TITLE
feat(backend): トーナメントセミファイナル画面ドラフト

### DIFF
--- a/apps/backend/src/apiServer/plugins/app/tournaments/match/manager.ts
+++ b/apps/backend/src/apiServer/plugins/app/tournaments/match/manager.ts
@@ -91,6 +91,12 @@ export function createMatchManager(tournaments: Map<string, Tournament>) {
       match.score = score;
       match.status = "completed";
 
+      // TODO: セミファイナルの両方のマッチが完了したら、ファイナルマッチを自動生成
+      // - tournament.matches から round === "semifinals" のマッチを取得
+      // - 全てのセミファイナルマッチが completed かチェック
+      // - 完了していれば、各マッチの勝者（winnerId）を取得
+      // - 勝者2名でファイナルマッチを生成（round: "finals"）
+
       return match;
     },
   };

--- a/apps/frontend/src/pages/tournaments/constants.ts
+++ b/apps/frontend/src/pages/tournaments/constants.ts
@@ -1,0 +1,42 @@
+// トーナメント画面の共通定数
+
+/** トーナメントステータスの定数 */
+export const TOURNAMENT_STATUS = {
+  WAITING: "waiting",
+  READY: "ready",
+  IN_PROGRESS: "in_progress",
+  COMPLETED: "completed",
+} as const;
+
+/** マッチステータスの定数 */
+export const MATCH_STATUS = {
+  PENDING: "pending",
+  IN_PROGRESS: "in_progress",
+  COMPLETED: "completed",
+} as const;
+
+/** マッチラウンドの定数 */
+export const MATCH_ROUND = {
+  SEMIFINALS: "semifinals",
+  FINALS: "finals",
+  THIRD_PLACE: "third_place",
+} as const;
+
+/** ステータスの日本語ラベル */
+export const STATUS_LABELS: Record<string, string> = {
+  waiting: "待機中",
+  ready: "準備完了",
+  in_progress: "進行中",
+  completed: "完了",
+};
+
+/** エラーメッセージの定数 */
+export const ERROR_MESSAGES = {
+  GENERIC: "エラーが発生しました",
+  TOURNAMENT_NOT_FOUND: "トーナメントが見つかりません",
+  MATCH_NOT_FOUND: "マッチが見つかりません",
+  NO_TOURNAMENTS: "トーナメントがありません",
+  NO_MATCHES: "まだマッチがありません",
+  NO_PLAYERS: "まだ参加者がいません",
+  LOADING: "読み込み中...",
+} as const;

--- a/apps/frontend/src/pages/tournaments/detail.ts
+++ b/apps/frontend/src/pages/tournaments/detail.ts
@@ -1,21 +1,16 @@
 import { componentFactory } from "../../factory/componentFactory";
 import { pageFactory } from "../../factory/pageFactory";
 import type { RouteCtx } from "../../routing/routeList";
-
-type Player = {
-  userId: number;
-  alias: string;
-};
-
-type Tournament = {
-  id: string;
-  name: string;
-  hostId: number;
-  maxPlayers: number;
-  players: Player[];
-  status: "waiting" | "ready" | "in_progress" | "completed";
-  createdAt: string;
-};
+import { ERROR_MESSAGES } from "./constants";
+import type { Player, Tournament } from "./types";
+import {
+  escapeHtml,
+  formatDate,
+  getStatusLabel,
+  navigateTo,
+  showError,
+  showLoading,
+} from "./utils";
 
 export function TournamentDetail(ctx: RouteCtx) {
   const tournamentId = ctx.params.id;
@@ -26,7 +21,7 @@ export function TournamentDetail(ctx: RouteCtx) {
   el.innerHTML = `
     <div class="max-w-4xl mx-auto">
       <div id="tournamentDetail">
-        <p class="text-gray-500">読み込み中...</p>
+        <p class="text-gray-500">${ERROR_MESSAGES.LOADING}</p>
       </div>
     </div>
   `;
@@ -35,13 +30,14 @@ export function TournamentDetail(ctx: RouteCtx) {
     "#tournamentDetail",
   ) as HTMLDivElement;
 
+  // トーナメント詳細を読み込む
   async function loadTournamentDetail() {
     try {
+      showLoading(detailContainer);
       const response = await fetch(`/api/tournaments/${tournamentId}`);
 
       if (!response.ok) {
-        detailContainer.innerHTML =
-          '<p class="text-red-500">トーナメントが見つかりません</p>';
+        showError(detailContainer, ERROR_MESSAGES.TOURNAMENT_NOT_FOUND);
         return;
       }
 
@@ -52,14 +48,14 @@ export function TournamentDetail(ctx: RouteCtx) {
           <a href="/tournaments" class="text-blue-500 hover:underline">&larr; 一覧に戻る</a>
         </div>
 
-        <h1 class="text-3xl font-bold mb-6">${tournament.name}</h1>
+        <h1 class="text-3xl font-bold mb-6">${escapeHtml(tournament.name)}</h1>
 
         <div class="bg-white shadow rounded-lg p-6 mb-6">
           <h2 class="text-xl font-semibold mb-4">トーナメント情報</h2>
           <dl class="space-y-2">
             <div class="flex">
               <dt class="font-semibold w-32">ステータス:</dt>
-              <dd>${getStatusLabel(tournament.status)}</dd>
+              <dd>${escapeHtml(getStatusLabel(tournament.status))}</dd>
             </div>
             <div class="flex">
               <dt class="font-semibold w-32">最大人数:</dt>
@@ -67,11 +63,11 @@ export function TournamentDetail(ctx: RouteCtx) {
             </div>
             <div class="flex">
               <dt class="font-semibold w-32">現在の参加者:</dt>
-              <dd>${tournament.players.length}人</dd>
+              <dd>${tournament.players?.length ?? 0}人</dd>
             </div>
             <div class="flex">
               <dt class="font-semibold w-32">作成日時:</dt>
-              <dd>${new Date(tournament.createdAt).toLocaleString()}</dd>
+              <dd>${formatDate(tournament.createdAt)}</dd>
             </div>
           </dl>
         </div>
@@ -79,15 +75,15 @@ export function TournamentDetail(ctx: RouteCtx) {
         <div class="bg-white shadow rounded-lg p-6 mb-6">
           <h2 class="text-xl font-semibold mb-4">参加者一覧</h2>
           ${
-            tournament.players.length === 0
-              ? '<p class="text-gray-500">まだ参加者がいません</p>'
+            !tournament.players || tournament.players.length === 0
+              ? `<p class="text-gray-500">${ERROR_MESSAGES.NO_PLAYERS}</p>`
               : `
               <ul class="space-y-2">
                 ${tournament.players
                   .map(
                     (p: Player) => `
                   <li class="flex items-center justify-between p-2 border rounded">
-                    <span>${p.alias}</span>
+                    <span>${escapeHtml(p.alias)}</span>
                     ${p.userId === tournament.hostId ? '<span class="text-xs bg-yellow-100 text-yellow-800 px-2 py-1 rounded">ホスト</span>' : ""}
                   </li>
                 `,
@@ -108,71 +104,66 @@ export function TournamentDetail(ctx: RouteCtx) {
         </div>
       `;
 
-      // 参加ボタン
+      // 参加ボタンのイベントリスナーを設定
       const joinBtn = detailContainer.querySelector("#joinBtn");
       if (joinBtn) {
-        joinBtn.addEventListener("click", async () => {
-          const alias = prompt("プレイヤー名を入力してください:");
-          if (!alias) return;
-
-          try {
-            const res = await fetch(`/api/tournaments/${tournamentId}/join`, {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              credentials: "include",
-              body: JSON.stringify({ alias }),
-            });
-
-            if (res.ok) {
-              loadTournamentDetail();
-            } else {
-              const error = await res.json();
-              alert(`参加に失敗しました: ${error.error}`);
-            }
-          } catch (_error) {
-            alert("エラーが発生しました");
-          }
-        });
+        joinBtn.addEventListener("click", () => handleJoin());
       }
 
-      // 開始ボタン
+      // 開始ボタンのイベントリスナーを設定
       const startBtn = detailContainer.querySelector("#startBtn");
       if (startBtn) {
-        startBtn.addEventListener("click", async () => {
-          if (!confirm("トーナメントを開始しますか？")) return;
-
-          try {
-            const res = await fetch(`/api/tournaments/${tournamentId}/start`, {
-              method: "POST",
-              credentials: "include",
-            });
-
-            if (res.ok) {
-              loadTournamentDetail();
-            } else {
-              const error = await res.json();
-              alert(`開始に失敗しました: ${error.error}`);
-            }
-          } catch (_error) {
-            alert("エラーが発生しました");
-          }
-        });
+        startBtn.addEventListener("click", () => handleStart());
       }
     } catch (error) {
-      detailContainer.innerHTML =
-        '<p class="text-red-500">エラーが発生しました</p>';
+      showError(detailContainer);
       console.error("Failed to load tournament detail:", error);
     }
   }
 
-  function getStatusLabel(status: string): string {
-    const labels: Record<string, string> = {
-      waiting: "待機中",
-      ready: "準備完了",
-      in_progress: "進行中",
-      completed: "完了",
-    };
-    return labels[status] || status;
+  // トーナメントに参加
+  async function handleJoin() {
+    const alias = prompt("プレイヤー名を入力してください:");
+    if (!alias) return;
+
+    try {
+      const res = await fetch(`/api/tournaments/${tournamentId}/join`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ alias }),
+      });
+
+      if (res.ok) {
+        loadTournamentDetail();
+      } else {
+        const error = await res.json();
+        alert(`参加に失敗しました: ${error.error}`);
+      }
+    } catch (_error) {
+      alert(ERROR_MESSAGES.GENERIC);
+    }
+  }
+
+  // トーナメントを開始
+  async function handleStart() {
+    if (!confirm("トーナメントを開始しますか？")) return;
+
+    try {
+      const res = await fetch(`/api/tournaments/${tournamentId}/start`, {
+        method: "POST",
+        credentials: "include",
+      });
+
+      if (res.ok) {
+        navigateTo(`/tournaments/${tournamentId}/semifinal`);
+      } else {
+        const error = await res.json();
+        alert(`開始に失敗しました: ${error.error}`);
+      }
+    } catch (_error) {
+      alert(ERROR_MESSAGES.GENERIC);
+    }
   }
 
   loadTournamentDetail();

--- a/apps/frontend/src/pages/tournaments/index.ts
+++ b/apps/frontend/src/pages/tournaments/index.ts
@@ -1,15 +1,16 @@
 import { componentFactory } from "../../factory/componentFactory";
 import { pageFactory } from "../../factory/pageFactory";
-
-type Tournament = {
-  id: string;
-  name: string;
-  hostId: number;
-  maxPlayers: number;
-  currentPlayers: number;
-  status: "waiting" | "ready" | "in_progress" | "completed";
-  createdAt: string;
-};
+import { ERROR_MESSAGES } from "./constants";
+import type { Tournament } from "./types";
+import {
+  escapeHtml,
+  formatDate,
+  getStatusLabel,
+  navigateTo,
+  showError,
+  showInfo,
+  showLoading,
+} from "./utils";
 
 function createTournamentsPage() {
   const el = document.createElement("div");
@@ -25,7 +26,7 @@ function createTournamentsPage() {
       </div>
 
       <div id="tournamentsList" class="space-y-4">
-        <p class="text-gray-500">読み込み中...</p>
+        <p class="text-gray-500">${ERROR_MESSAGES.LOADING}</p>
       </div>
     </div>
 
@@ -64,71 +65,67 @@ function createTournamentsPage() {
     "#tournamentName",
   ) as HTMLInputElement;
 
-  // トーナメント一覧取得
+  // トーナメント一覧を読み込む
   async function loadTournaments() {
     try {
+      showLoading(tournamentsList);
       const response = await fetch("/api/tournaments");
       const tournaments = await response.json();
 
       if (tournaments.length === 0) {
-        tournamentsList.innerHTML =
-          '<p class="text-gray-500">トーナメントがありません</p>';
+        showInfo(tournamentsList, ERROR_MESSAGES.NO_TOURNAMENTS);
         return;
       }
 
       tournamentsList.innerHTML = tournaments
-        .map(
-          (t: Tournament) => `
-        <div class="border border-gray-300 rounded p-4 hover:shadow-lg transition-shadow cursor-pointer" data-id="${t.id}">
-          <div class="flex justify-between items-start">
-            <div>
-              <h3 class="text-xl font-semibold">${t.name}</h3>
-              <p class="text-sm text-gray-600">プレイヤー: ${t.currentPlayers}/${t.maxPlayers}</p>
-              <p class="text-sm text-gray-600">ステータス: ${getStatusLabel(t.status)}</p>
+        .map((t: Tournament) => {
+          const name = escapeHtml(t.name);
+          const status = escapeHtml(getStatusLabel(t.status));
+          const date = formatDate(t.createdAt);
+
+          return `
+            <div class="border border-gray-300 rounded p-4 hover:shadow-lg transition-shadow cursor-pointer" data-id="${t.id}">
+              <div class="flex justify-between items-start">
+                <div>
+                  <h3 class="text-xl font-semibold">${name}</h3>
+                  <p class="text-sm text-gray-600">プレイヤー: ${t.currentPlayers}/${t.maxPlayers}</p>
+                  <p class="text-sm text-gray-600">ステータス: ${status}</p>
+                </div>
+                <span class="text-xs text-gray-500">${date}</span>
+              </div>
             </div>
-            <span class="text-xs text-gray-500">${new Date(t.createdAt).toLocaleString()}</span>
-          </div>
-        </div>
-      `,
-        )
+          `;
+        })
         .join("");
 
-      // クリックイベント追加
+      // トーナメントカードのクリックイベントを追加
       tournamentsList.querySelectorAll("[data-id]").forEach((card) => {
-        card.addEventListener("click", () => {
+        card.addEventListener("click", (e) => {
+          e.preventDefault();
           const id = card.getAttribute("data-id");
-          window.location.href = `/tournaments/${id}`;
+          if (id) navigateTo(`/tournaments/${id}`);
         });
       });
     } catch (error) {
-      tournamentsList.innerHTML =
-        '<p class="text-red-500">エラーが発生しました</p>';
+      showError(tournamentsList);
       console.error("Failed to load tournaments:", error);
     }
   }
 
-  function getStatusLabel(status: string): string {
-    const labels: Record<string, string> = {
-      waiting: "待機中",
-      ready: "準備完了",
-      in_progress: "進行中",
-      completed: "完了",
-    };
-    return labels[status] || status;
-  }
-
-  // モーダル表示
+  // 作成モーダルを表示
   createTournamentBtn.addEventListener("click", () => {
     createModal.classList.remove("hidden");
   });
 
-  // モーダル非表示
-  cancelBtn.addEventListener("click", () => {
+  // モーダルを閉じる
+  function closeModal() {
     createModal.classList.add("hidden");
     tournamentNameInput.value = "";
-  });
+  }
 
-  // トーナメント作成
+  cancelBtn.addEventListener("click", closeModal);
+
+  // トーナメントを作成
   createBtn.addEventListener("click", async () => {
     const name = tournamentNameInput.value.trim();
     if (!name) {
@@ -145,15 +142,14 @@ function createTournamentsPage() {
       });
 
       if (response.ok) {
-        createModal.classList.add("hidden");
-        tournamentNameInput.value = "";
+        closeModal();
         loadTournaments();
       } else {
         const error = await response.json();
         alert(`作成に失敗しました: ${error.error}`);
       }
     } catch (error) {
-      alert("エラーが発生しました");
+      alert(ERROR_MESSAGES.GENERIC);
       console.error("Failed to create tournament:", error);
     }
   });

--- a/apps/frontend/src/pages/tournaments/semifinal.ts
+++ b/apps/frontend/src/pages/tournaments/semifinal.ts
@@ -1,0 +1,264 @@
+import { componentFactory } from "../../factory/componentFactory";
+import { pageFactory } from "../../factory/pageFactory";
+import type { RouteCtx } from "../../routing/routeList";
+import { ERROR_MESSAGES, MATCH_ROUND } from "./constants";
+import type { Match, Tournament } from "./types";
+import { escapeHtml, showError, showInfo, showLoading } from "./utils";
+
+export function TournamentSemifinal(ctx: RouteCtx) {
+  const tournamentId = ctx.params.id;
+
+  const el = document.createElement("div");
+  el.className = "min-h-screen bg-gray-100";
+
+  el.innerHTML = `
+    <div class="container mx-auto p-8">
+      <div class="max-w-4xl mx-auto">
+        <!-- Header -->
+        <div class="mb-6">
+          <h1 id="tournamentName" class="text-3xl font-bold text-center mb-2">Remote Tournament</h1>
+          <div class="text-center">
+            <a href="/tournaments" class="text-blue-500 hover:underline">← Back to Home</a>
+          </div>
+        </div>
+
+        <!-- Tabs -->
+        <div class="flex justify-center mb-8 border-b border-gray-300">
+          <button id="tabRound1" class="px-6 py-3 font-semibold text-green-600 border-b-2 border-green-600">
+            Round 1
+          </button>
+          <button id="tabFinals" class="px-6 py-3 font-semibold text-gray-600 hover:text-green-600">
+            Finals
+          </button>
+          <button id="tabResults" class="px-6 py-3 font-semibold text-gray-600 hover:text-green-600">
+            Results
+          </button>
+        </div>
+
+        <!-- Matches Container -->
+        <div id="matchesContainer" class="space-y-6">
+          <p class="text-gray-500 text-center">${ERROR_MESSAGES.LOADING}</p>
+        </div>
+      </div>
+    </div>
+  `;
+
+  const tournamentNameEl = el.querySelector(
+    "#tournamentName",
+  ) as HTMLHeadingElement;
+  const matchesContainer = el.querySelector(
+    "#matchesContainer",
+  ) as HTMLDivElement;
+  const tabRound1 = el.querySelector("#tabRound1") as HTMLButtonElement;
+  const tabFinals = el.querySelector("#tabFinals") as HTMLButtonElement;
+  const tabResults = el.querySelector("#tabResults") as HTMLButtonElement;
+
+  // トーナメント情報を読み込む
+  async function loadTournament() {
+    try {
+      const response = await fetch(`/api/tournaments/${tournamentId}`);
+      if (!response.ok) {
+        showError(matchesContainer, ERROR_MESSAGES.TOURNAMENT_NOT_FOUND);
+        return;
+      }
+
+      const tournament: Tournament = await response.json();
+      tournamentNameEl.textContent = tournament.name;
+
+      await loadMatches();
+    } catch (error) {
+      showError(matchesContainer);
+      console.error("Failed to load tournament:", error);
+    }
+  }
+
+  // マッチ一覧を読み込む
+  async function loadMatches() {
+    try {
+      showLoading(matchesContainer);
+      const response = await fetch(`/api/tournaments/${tournamentId}/matches`);
+      if (!response.ok) {
+        showError(matchesContainer, ERROR_MESSAGES.MATCH_NOT_FOUND);
+        return;
+      }
+
+      const data = await response.json();
+      const matches: Match[] = data.matches || [];
+
+      // セミファイナルのマッチのみフィルタリング
+      const semifinalMatches = matches.filter(
+        (m) => m.round === MATCH_ROUND.SEMIFINALS,
+      );
+
+      if (semifinalMatches.length === 0) {
+        showInfo(matchesContainer, ERROR_MESSAGES.NO_MATCHES);
+        return;
+      }
+
+      matchesContainer.innerHTML = semifinalMatches
+        .map((match) => createMatchCard(match))
+        .join("");
+
+      // 各マッチの開始ボタンにイベントリスナーを追加
+      semifinalMatches.forEach((match) => {
+        const btn = el.querySelector(
+          `#startMatch-${match.id}`,
+        ) as HTMLButtonElement;
+        if (btn) {
+          btn.addEventListener("click", () => startMatch(match.id));
+        }
+      });
+    } catch (error) {
+      showError(matchesContainer);
+      console.error("Failed to load matches:", error);
+    }
+  }
+
+  // マッチカードのHTMLを生成
+  function createMatchCard(match: Match): string {
+    const player1Name = escapeHtml(match.player1?.alias || "TBD");
+    const player2Name = escapeHtml(match.player2?.alias || "TBD");
+    const isStartable =
+      match.status === "pending" && match.player1 && match.player2;
+
+    return `
+      <div class="bg-white shadow-lg rounded-lg p-6">
+        <div class="flex items-center justify-between">
+          <div class="flex items-center space-x-4 flex-1">
+            <span class="text-lg font-semibold">${player1Name}</span>
+            <span class="text-gray-500">VS</span>
+            <span class="text-lg font-semibold">${player2Name}</span>
+          </div>
+          <button
+            id="startMatch-${match.id}"
+            class="bg-black hover:bg-gray-800 text-white font-bold py-2 px-6 rounded ${!isStartable ? "opacity-50 cursor-not-allowed" : ""}"
+            ${!isStartable ? "disabled" : ""}
+          >
+            Start Match
+          </button>
+        </div>
+      </div>
+    `;
+  }
+
+  // マッチを開始
+  async function startMatch(matchId: string) {
+    try {
+      // マッチ情報を取得して勝者を決定
+      const matchesResponse = await fetch(
+        `/api/tournaments/${tournamentId}/matches`,
+      );
+      if (!matchesResponse.ok) {
+        alert("マッチ情報の取得に失敗しました");
+        return;
+      }
+
+      const matchesData = await matchesResponse.json();
+      const currentMatch = matchesData.matches?.find(
+        (m: Match) => m.id === matchId,
+      );
+      if (!currentMatch) {
+        alert("マッチが見つかりません");
+        return;
+      }
+
+      // マッチを開始
+      const startResponse = await fetch(
+        `/api/tournaments/${tournamentId}/matches/${matchId}/start`,
+        {
+          method: "POST",
+          credentials: "include",
+        },
+      );
+
+      if (!startResponse.ok) {
+        const error = await startResponse.json();
+        alert(`マッチ開始に失敗しました: ${error.error}`);
+        return;
+      }
+
+      alert("マッチが開始されました");
+
+      // TODO: 実際のゲーム画面に遷移してプレイ
+      // 現在は仮の結果を送信（player1が5点、player2が3点で勝利）
+
+      // 仮の結果を送信（5 vs 3、player1の勝利）
+      const resultResponse = await fetch(
+        `/api/tournaments/${tournamentId}/matches/${matchId}/result`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify({
+            winnerId: currentMatch.player1.userId, // player1を勝者とする
+            score: {
+              player1: 5,
+              player2: 3,
+            },
+          }),
+        },
+      );
+
+      if (resultResponse.ok) {
+        alert(
+          `マッチ結果を送信しました\n${currentMatch.player1.alias}: 5 vs ${currentMatch.player2.alias}: 3`,
+        );
+        loadMatches();
+      } else {
+        const error = await resultResponse.json();
+        alert(`結果送信に失敗しました: ${error.error}`);
+      }
+    } catch (error) {
+      alert(ERROR_MESSAGES.GENERIC);
+      console.error("Failed to start match:", error);
+    }
+  }
+
+  // タブ切り替えのイベントリスナー
+  tabRound1.addEventListener("click", () => {
+    setActiveTab("round1");
+    loadMatches();
+  });
+
+  tabFinals.addEventListener("click", () => {
+    setActiveTab("finals");
+    // TODO: ファイナル画面を実装
+    // - round === "finals" のマッチを表示
+    // - ファイナルマッチが存在しない場合は「ファイナルマッチはまだ生成されていません」を表示
+    alert("Finals page is not yet implemented");
+  });
+
+  tabResults.addEventListener("click", () => {
+    setActiveTab("results");
+    // TODO: 結果画面を実装
+    // - トーナメントの最終順位を表示
+    // - 1位: ファイナルの勝者
+    // - 2位: ファイナルの敗者
+    // - 3-4位: セミファイナルの敗者
+    alert("Results page is not yet implemented");
+  });
+
+  // アクティブなタブを設定
+  function setActiveTab(tab: "round1" | "finals" | "results") {
+    const tabs = [
+      { element: tabRound1, name: "round1" },
+      { element: tabFinals, name: "finals" },
+      { element: tabResults, name: "results" },
+    ];
+
+    tabs.forEach(({ element, name }) => {
+      if (name === tab) {
+        element.className =
+          "px-6 py-3 font-semibold text-green-600 border-b-2 border-green-600";
+      } else {
+        element.className =
+          "px-6 py-3 font-semibold text-gray-600 hover:text-green-600";
+      }
+    });
+  }
+
+  loadTournament();
+
+  const component = componentFactory(el);
+  return pageFactory([component]);
+}

--- a/apps/frontend/src/pages/tournaments/types.ts
+++ b/apps/frontend/src/pages/tournaments/types.ts
@@ -1,0 +1,44 @@
+/** トーナメントのステータス */
+export type TournamentStatus =
+  | "waiting"
+  | "ready"
+  | "in_progress"
+  | "completed";
+
+/** マッチのステータス */
+export type MatchStatus = "pending" | "in_progress" | "completed";
+
+/** マッチのラウンド */
+export type MatchRound = "semifinals" | "finals" | "third_place";
+
+/** プレイヤー情報 */
+export type Player = {
+  userId: number;
+  alias: string;
+};
+
+/** トーナメント情報 */
+export type Tournament = {
+  id: string; // トーナメントID
+  name: string; // トーナメント名
+  hostId: number; // ホストのユーザーID
+  maxPlayers: number; // 最大参加人数
+  players?: Player[]; // 参加者リスト
+  currentPlayers?: number; // 現在の参加人数
+  status: TournamentStatus; // ステータス
+  createdAt: string; // 作成日時
+};
+
+/** マッチ情報 */
+export type Match = {
+  id: string; // マッチID
+  round: MatchRound; // ラウンド
+  player1: Player; // プレイヤー1
+  player2: Player; // プレイヤー2
+  status: MatchStatus; // ステータス
+  score?: {
+    // スコア（任意）
+    player1: number; // プレイヤー1のスコア
+    player2: number; // プレイヤー2のスコア
+  };
+};

--- a/apps/frontend/src/pages/tournaments/utils.ts
+++ b/apps/frontend/src/pages/tournaments/utils.ts
@@ -1,0 +1,69 @@
+import { ERROR_MESSAGES, STATUS_LABELS } from "./constants";
+
+/**
+ * ステータスの日本語ラベルを取得
+ * @param status - ステータス文字列
+ * @returns 日本語ラベル（存在しない場合は元の文字列）
+ */
+export function getStatusLabel(status: string): string {
+  return STATUS_LABELS[status] || status;
+}
+
+/**
+ * SPAルーターを使用してURLに遷移
+ * @param url - 遷移先のURL
+ */
+export function navigateTo(url: string): void {
+  const link = document.createElement("a");
+  link.href = url;
+  link.click();
+}
+
+/**
+ * コンテナにエラーメッセージを表示
+ * @param container - 表示先のHTML要素
+ * @param message - エラーメッセージ（デフォルト: 汎用エラーメッセージ）
+ */
+export function showError(
+  container: HTMLElement,
+  message: string = ERROR_MESSAGES.GENERIC,
+): void {
+  container.innerHTML = `<p class="text-red-500 text-center">${message}</p>`;
+}
+
+/**
+ * コンテナにローディングメッセージを表示
+ * @param container - 表示先のHTML要素
+ */
+export function showLoading(container: HTMLElement): void {
+  container.innerHTML = `<p class="text-gray-500 text-center">${ERROR_MESSAGES.LOADING}</p>`;
+}
+
+/**
+ * コンテナに情報メッセージを表示
+ * @param container - 表示先のHTML要素
+ * @param message - 情報メッセージ
+ */
+export function showInfo(container: HTMLElement, message: string): void {
+  container.innerHTML = `<p class="text-gray-500 text-center">${message}</p>`;
+}
+
+/**
+ * HTMLをエスケープしてXSS攻撃を防止
+ * @param text - エスケープする文字列
+ * @returns エスケープされたHTML文字列
+ */
+export function escapeHtml(text: string): string {
+  const div = document.createElement("div");
+  div.textContent = text;
+  return div.innerHTML;
+}
+
+/**
+ * 日付文字列をロケール形式にフォーマット
+ * @param dateString - ISO形式の日付文字列
+ * @returns ロケール形式の日付文字列
+ */
+export function formatDate(dateString: string): string {
+  return new Date(dateString).toLocaleString();
+}

--- a/apps/frontend/src/routing/routeList.ts
+++ b/apps/frontend/src/routing/routeList.ts
@@ -7,6 +7,7 @@ import { Home } from "../pages/main";
 import { pongPage } from "../pages/pong";
 import { Tournaments } from "../pages/tournaments";
 import { TournamentDetail } from "../pages/tournaments/detail";
+import { TournamentSemifinal } from "../pages/tournaments/semifinal";
 import { User } from "../pages/user/user";
 
 // { id: 15 } みたいなデータ。ユーザーidとかを扱うとき
@@ -82,6 +83,11 @@ export const routeList: Route[] = [
     meta: { title: "tournamentDetail" },
     path: "/tournaments/:id",
     viewFactory: (ctx: RouteCtx) => TournamentDetail(ctx),
+  },
+  {
+    meta: { title: "tournamentSemifinal" },
+    path: "/tournaments/:id/semifinal",
+    viewFactory: (ctx: RouteCtx) => TournamentSemifinal(ctx),
   },
   {
     meta: { title: "user" },


### PR DESCRIPTION
**トーナメント開始**: `POST /api/tournaments/:id/start`
  - トーナメントステータスを`in_progress`に変更
  - セミファイナルマッチを自動生成（4人のプレイヤーから2試合を生成）
    - Match 1: Player 1 vs Player 2
    - Match 2: Player 3 vs Player 4
 
**マッチ一覧取得**: `GET /api/tournaments/:id/matches`
   - マッチデータを取得
   - 成功時: レスポンスから`matches`配列を取得し、`round === "semifinals"`のマッチをフィルタリング
   - セミファイナルマッチが存在する場合: マッチカードを生成して表示

### 試合開始ボタンクリック時
1. **マッチ開始**: `POST /api/tournaments/:id/matches/:matchId/start`
2. **マッチ結果送信**（仮実装）: `POST /api/tournaments/:id/matches/:matchId/result`
   - リクエストヘッダー: `Content-Type: application/json`, `credentials: "include"`
   - リクエストボディ:
     ```json
     {
       "winnerId": "<player1のuserId>",
       "score": {
         "player1": 5,
         "player2": 3
       }
     }
     ```
> **Note**: 現在はマッチ開始を両者見ていないのでどちらもマッチ開始準備OKになったらpong画面に飛ぶように修正する予定
### 未実装の機能
- **ファイナル画面**
- **結果画面**

> **Note**: 現在は試合開始後すぐに仮の結果（player1勝利、5-3）を送信している、pong画面に遷移するして試合結果を返してもらう必要あり