### PR TITLE
feat(backend): トーナメントファイナルバックエンド基盤実装

### DIFF
--- a/apps/backend/src/apiServer/plugins/app/tournaments/match/manager.ts
+++ b/apps/backend/src/apiServer/plugins/app/tournaments/match/manager.ts
@@ -120,9 +120,7 @@ export function createMatchManager(tournaments: Map<string, Tournament>) {
 
     // 3位決定戦を生成
     if (losers.length === REQUIRED_FINAL_PLAYERS) {
-      tournament.matches.push(
-        createMatch("third_place", losers[0], losers[1]),
-      );
+      tournament.matches.push(createMatch("third_place", losers[0], losers[1]));
     }
   }
 


### PR DESCRIPTION
セミファイナルの結果が帰ってきたらファイナル、3位決定戦の試合を生成する
#122 で動作確認