### PR TITLE
chore(backend): 試合結果及びトーナメントのテーブル定義の追加

### DIFF
--- a/apps/backend/src/database/sql/schema.sql
+++ b/apps/backend/src/database/sql/schema.sql
@@ -5,3 +5,29 @@ CREATE TABLE IF NOT EXISTS users (
   ft_id INTEGER UNIQUE,
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE IF NOT EXISTS tournaments (
+  id TEXT NOT NULL PRIMARY KEY, -- UUID?
+  name TEXT NOT NULL,
+  host_id INTEGER NOT NULL,
+  winner_id INTEGER,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (host_id) REFERENCES users(id),
+  FOREIGN KEY (winner_id) REFERENCES users(id)
+);
+
+CREATE TABLE IF NOT EXISTS matches (
+  id TEXT NOT NULL PRIMARY KEY, -- UUID?
+  tournament_id TEXT NOT NULL,
+  round INTEGER NOT NULL, -- 1回戦なら1, 2回戦なら2など
+  player1_id INTEGER NOT NULL,
+  player2_id INTEGER NOT NULL,
+  player1_score INTEGER NOT NULL,
+  player2_score INTEGER NOT NULL,
+  winner_id INTEGER, -- スコアから判断できるが、クエリを簡単にするため
+  played_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (tournament_id) REFERENCES tournaments(id),
+  FOREIGN KEY (player1_id) REFERENCES users(id),
+  FOREIGN KEY (player2_id) REFERENCES users(id),
+  FOREIGN KEY (winner_id) REFERENCES users(id)
+);

--- a/docs/er.md
+++ b/docs/er.md
@@ -1,0 +1,37 @@
+```mermaid
+erDiagram
+    users {
+        INTEGER id PK
+        TEXT name
+        TEXT email
+        INTEGER ft_id UK
+        DATETIME created_at
+    }
+
+    tournaments {
+        TEXT id PK
+        TEXT name
+        INTEGER host_id FK
+        INTEGER winner_id FK
+        DATETIME created_at
+    }
+
+    matches {
+        TEXT id PK
+        TEXT tournament_id FK
+        INTEGER round
+        INTEGER player1_id FK
+        INTEGER player2_id FK
+        INTEGER player1_score
+        INTEGER player2_score
+        INTEGER winner_id FK
+        DATETIME played_at
+    }
+
+    users ||--o{ tournaments : "hosts"
+    users ||--o{ tournaments : "is_winner_of"
+    tournaments ||--|{ matches : "contains"
+    users ||--o{ matches : "is_player1"
+    users ||--o{ matches : "is_player2"
+    users ||--o{ matches : "wins_match"
+```


### PR DESCRIPTION
- テーブル定義とER図の追加を行った
- round: 1回戦なら1, 2回戦なら2とか。4人でのトーナメント(試合数3)の決勝は2になる。

```mermaid
erDiagram
    users {
        INTEGER id PK
        TEXT name
        TEXT email
        INTEGER ft_id UK
        DATETIME created_at
    }

    tournaments {
        TEXT id PK
        TEXT name
        INTEGER host_id FK
        INTEGER winner_id FK
        DATETIME created_at
    }

    matches {
        TEXT id PK
        TEXT tournament_id FK
        INTEGER round
        INTEGER player1_id FK
        INTEGER player2_id FK
        INTEGER player1_score
        INTEGER player2_score
        INTEGER winner_id FK
        DATETIME played_at
    }

    users ||--o{ tournaments : "hosts"
    users ||--o{ tournaments : "is_winner_of"
    tournaments ||--|{ matches : "contains"
    users ||--o{ matches : "is_player1"
    users ||--o{ matches : "is_player2"
    users ||--o{ matches : "wins_match"
```