### PR TITLE
chore(backend): matchs, tournamentsテーブル用の初期データを追加

### DIFF
--- a/apps/backend/src/database/sql/seed.sql
+++ b/apps/backend/src/database/sql/seed.sql
@@ -1,2 +1,13 @@
-INSERT OR IGNORE INTO users (name, email, ft_id) VALUES
-("John Doe", "john.doe@example.com", 100);
+INSERT OR IGNORE INTO users (id, name, email, ft_id) VALUES
+(1000, "John Doe", "john.doe@example.com", 1000),
+(1001, "Jane Smith", "jane.smith@example.com", 1001),
+(1002, "Alice Johnson", "alice.johnson@example.com", 1002),
+(1003, "Bob Brown", "bob.brown@example.com", 1003);
+
+INSERT OR IGNORE INTO tournaments (id, name, host_id, winner_id) VALUES
+("2f4d2306-ca5e-8145-7eb1-4b58773e466e", "AAAAA", 1000, 1000); -- uid1000主催、uid1000優勝
+
+INSERT OR IGNORE INTO matches (id, tournament_id, round, player1_id, player2_id, player1_score, player2_score, winner_id) VALUES
+("29e5f9ec-186c-adb1-618e-2d1da0095654", "2f4d2306-ca5e-8145-7eb1-4b58773e466e", 1, 1000, 1001, 3, 2, 1000), -- 1回戦 1000 vs 1001, 3-2で1000の勝ち
+("39e5f9ec-186c-adb1-618e-2d1da0095654", "2f4d2306-ca5e-8145-7eb1-4b58773e466e", 1, 1002, 1003, 1, 3, 1003), -- 1回戦 1002 vs 1003, 1-3で1003の勝ち
+("49e5f9ec-186c-adb1-618e-2d1da0095654", "2f4d2306-ca5e-8145-7eb1-4b58773e466e", 2, 1000, 1003, 3, 0, 1000); -- 決勝(2回戦) 1000 vs 1003, 3-0で1000の勝ち


### PR DESCRIPTION
- 動作確認のため、backend起動時にmatchs, tournamentsテーブルに初期データを流し込むようにした。

<img width="1185" height="649" alt="スクリーンショット 2025-10-16 19 57 36" src="https://github.com/user-attachments/assets/368d9162-ff39-413f-ac38-6c50384e827a" />
