### PR TITLE
deps(misc): 依存関係のピン+未使用の依存関係の削除

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -10,14 +10,14 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "@vitest/ui": "^3.2.4",
-    "jsdom": "^27.0.0",
-    "typescript": "~5.8.3",
-    "vite": "^7.1.7",
-    "vitest": "^3.2.4"
+    "@vitest/ui": "3.2.4",
+    "jsdom": "27.0.0",
+    "typescript": "5.8.3",
+    "vite": "7.1.7",
+    "vitest": "3.2.4"
   },
   "dependencies": {
-    "@tailwindcss/vite": "^4.1.13",
-    "tailwindcss": "^4.1.13"
+    "@tailwindcss/vite": "4.1.13",
+    "tailwindcss": "4.1.13"
   }
 }

--- a/apps/game/package.json
+++ b/apps/game/package.json
@@ -20,17 +20,17 @@
   "license": "ISC",
   "packageManager": "pnpm@10.17.1",
   "dependencies": {
-    "@fastify/http-proxy": "^11.3.0",
-    "@fastify/websocket": "^11.2.0",
+    "@fastify/http-proxy": "11.3.0",
+    "@fastify/websocket": "11.2.0",
     "@types/node": "24.5.2",
-    "crypto": "^1.0.1",
+    "crypto": "1.0.1",
     "dotenv": "17.2.2",
     "fastify": "5.6.1",
     "tsup": "8.5.0",
     "tsx": "4.20.5",
-    "typescript": "^5.9.3"
+    "typescript": "5.9.3"
   },
   "devDependencies": {
-    "@types/ws": "^8.18.1"
+    "@types/ws": "8.18.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,8 +25,5 @@
   },
   "lefthook": {
     "version": "1.13.3"
-  },
-  "dependencies": {
-    "fastify": "5.6.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      fastify:
-        specifier: 5.6.1
-        version: 5.6.1
     devDependencies:
       '@biomejs/biome':
         specifier: 2.2.4
@@ -74,41 +70,41 @@ importers:
   apps/frontend:
     dependencies:
       '@tailwindcss/vite':
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13(vite@7.1.7(@types/node@24.5.2)(jiti@2.6.0)(lightningcss@1.30.1)(tsx@4.20.5)(yaml@2.8.1))
       tailwindcss:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
     devDependencies:
       '@vitest/ui':
-        specifier: ^3.2.4
+        specifier: 3.2.4
         version: 3.2.4(vitest@3.2.4)
       jsdom:
-        specifier: ^27.0.0
+        specifier: 27.0.0
         version: 27.0.0(postcss@8.5.6)
       typescript:
-        specifier: ~5.8.3
+        specifier: 5.8.3
         version: 5.8.3
       vite:
-        specifier: ^7.1.7
+        specifier: 7.1.7
         version: 7.1.7(@types/node@24.5.2)(jiti@2.6.0)(lightningcss@1.30.1)(tsx@4.20.5)(yaml@2.8.1)
       vitest:
-        specifier: ^3.2.4
+        specifier: 3.2.4
         version: 3.2.4(@types/node@24.5.2)(@vitest/ui@3.2.4)(jiti@2.6.0)(jsdom@27.0.0(postcss@8.5.6))(lightningcss@1.30.1)(tsx@4.20.5)(yaml@2.8.1)
 
   apps/game:
     dependencies:
       '@fastify/http-proxy':
-        specifier: ^11.3.0
+        specifier: 11.3.0
         version: 11.3.0
       '@fastify/websocket':
-        specifier: ^11.2.0
+        specifier: 11.2.0
         version: 11.2.0
       '@types/node':
         specifier: 24.5.2
         version: 24.5.2
       crypto:
-        specifier: ^1.0.1
+        specifier: 1.0.1
         version: 1.0.1
       dotenv:
         specifier: 17.2.2
@@ -123,11 +119,11 @@ importers:
         specifier: 4.20.5
         version: 4.20.5
       typescript:
-        specifier: ^5.9.3
+        specifier: 5.9.3
         version: 5.9.3
     devDependencies:
       '@types/ws':
-        specifier: ^8.18.1
+        specifier: 8.18.1
         version: 8.18.1
 
 packages:
@@ -1771,6 +1767,7 @@ packages:
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
 
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}


### PR DESCRIPTION
- 依存関係のピン止め(^などの削除)を行った。これにより、意図しないバージョン更新による課題プログラムの挙動変更が起こらないようにする。
- ルートのpackage.jsonからfastifyを削除。apps以下のpackage.jsonには適切にfastifyがインストールされるため、ルートに記載する必要はない。(pnpmの特性でシンボリックリンクになるため、ファイルサイズ的なメリットはなし)