### PR TITLE
chore(backend): uuidの生成をv4からv7に変更

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -30,6 +30,7 @@
     "jsonwebtoken": "9.0.2",
     "sqlite": "5.1.1",
     "sqlite3": "5.1.7",
+    "uuid": "13.0.0",
     "zod": "4.1.11"
   },
   "devDependencies": {

--- a/apps/backend/src/apiServer/plugins/app/tournaments/match/manager.ts
+++ b/apps/backend/src/apiServer/plugins/app/tournaments/match/manager.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { v7 as uuidv7 } from "uuid";
 import type { GameOptions, Match, Player, Tournament } from "../types.js";
 
 const REQUIRED_SEMIFINAL_MATCHES = 2;
@@ -54,7 +54,7 @@ export function createMatchManager(tournaments: Map<string, Tournament>) {
     gameOptions: GameOptions,
   ): Match {
     return {
-      id: randomUUID(),
+      id: uuidv7(),
       round,
       leftPlayer,
       rightPlayer,

--- a/apps/backend/src/apiServer/plugins/app/tournaments/tournament/manager.ts
+++ b/apps/backend/src/apiServer/plugins/app/tournaments/tournament/manager.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { v7 as uuidv7 } from "uuid";
 import type { GameOptions, Tournament } from "../types.js";
 
 export function createTournamentManager(tournaments: Map<string, Tournament>) {
@@ -18,7 +18,7 @@ export function createTournamentManager(tournaments: Map<string, Tournament>) {
       maxPlayers: number = 4,
     ): Tournament {
       const tournament: Tournament = {
-        id: randomUUID(),
+        id: uuidv7(),
         name,
         hostId,
         maxPlayers,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       sqlite3:
         specifier: 5.1.7
         version: 5.1.7
+      uuid:
+        specifier: 13.0.0
+        version: 13.0.0
       zod:
         specifier: 4.1.11
         version: 4.1.11
@@ -2010,6 +2013,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@13.0.0:
+    resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
+    hasBin: true
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -4061,6 +4068,8 @@ snapshots:
     optional: true
 
   util-deprecate@1.0.2: {}
+
+  uuid@13.0.0: {}
 
   vite-node@3.2.4(@types/node@24.5.2)(jiti@2.6.0)(lightningcss@1.30.1)(tsx@4.20.5)(yaml@2.8.1):
     dependencies:


### PR DESCRIPTION
- DBへの登録が発生するトーナメントとマッチの主キーについて、完全ランダムなuuid v4から、時間情報を含むuuid v7に変更した。これは、DBの検索速度の向上を意図している。